### PR TITLE
Implement eventual consistency for token stats

### DIFF
--- a/src/app/api/conversations/[id]/messages/[messageId]/stats/route.ts
+++ b/src/app/api/conversations/[id]/messages/[messageId]/stats/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { initDb, getDb } from '@/lib/db';
+
+/**
+ * PATCH /api/conversations/[id]/messages/[messageId]/stats
+ *
+ * Persists resolved stats to the database when they become available.
+ */
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string; messageId: string }> }
+) {
+  const { id: conversationId, messageId } = await params;
+  const { stats } = await request.json();
+
+  await initDb();
+  const client = getDb();
+
+  // Fetch current metadata
+  const result = await client.execute({
+    sql: `SELECT metadata FROM messages WHERE id = ? AND conversation_id = ?`,
+    args: [messageId, conversationId],
+  });
+
+  if (result.rows.length === 0) {
+    return NextResponse.json({ error: 'Message not found' }, { status: 404 });
+  }
+
+  // Parse and merge metadata
+  const currentMetadata = result.rows[0].metadata
+    ? JSON.parse(result.rows[0].metadata as string)
+    : {};
+
+  const updatedMetadata = {
+    ...currentMetadata,
+    stats: { ...currentMetadata.stats, ...stats },
+  };
+
+  // Update database
+  await client.execute({
+    sql: `UPDATE messages SET metadata = ? WHERE id = ? AND conversation_id = ?`,
+    args: [JSON.stringify(updatedMetadata), messageId, conversationId],
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/stats/[rootSpanId]/route.ts
+++ b/src/app/api/stats/[rootSpanId]/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import { initDb, getDb } from '@/lib/db';
+import { fetchTraceStats } from '@/lib/braintrust-api';
+
+/**
+ * GET /api/stats/[rootSpanId]?conversationId=xxx
+ *
+ * Polling endpoint for fetching token stats with eventual consistency.
+ * Validates that the rootSpanId belongs to a message in the specified conversation.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ rootSpanId: string }> }
+) {
+  const { rootSpanId } = await params;
+  const { searchParams } = new URL(request.url);
+  const conversationId = searchParams.get('conversationId');
+
+  // Security: Require conversationId to validate ownership
+  if (!conversationId) {
+    return NextResponse.json({ error: 'conversationId required' }, { status: 400 });
+  }
+
+  // Validate rootSpanId belongs to a message in this conversation
+  await initDb();
+  const client = getDb();
+  const result = await client.execute({
+    sql: `SELECT id FROM messages
+          WHERE conversation_id = ?
+          AND metadata LIKE ?
+          LIMIT 1`,
+    args: [conversationId, `%"rootSpanId":"${rootSpanId}"%`],
+  });
+
+  if (result.rows.length === 0) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  // Fetch stats from Braintrust
+  const stats = await fetchTraceStats(rootSpanId);
+
+  return NextResponse.json({
+    status: stats ? 'resolved' : 'pending',
+    stats: stats ? {
+      promptTokens: stats.promptTokens,
+      completionTokens: stats.completionTokens,
+      cachedTokens: stats.cachedTokens,
+      reasoningTokens: stats.reasoningTokens,
+    } : null,
+  });
+}

--- a/src/components/ChatClient.tsx
+++ b/src/components/ChatClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { useTsugiChat, Message } from '@/hooks/useTsugiChat';
+import { useTsugiChat, Message, MessageStats } from '@/hooks/useTsugiChat';
 import { useConversations } from '@/hooks/useConversations';
 import ChatMessage, { SkillSuggestion } from './ChatMessage';
 import { CumulativeStatsBar } from './CumulativeStats';
@@ -328,6 +328,18 @@ export default function ChatClient({
         const textContent = textPart?.text || '';
         const title = textContent.slice(0, 50) || 'New conversation';
         await renameConversation(conversationId, title);
+      }
+    },
+    // Persist resolved stats to DB when they become available via polling
+    onStatsResolved: async (messageId: string, stats: MessageStats) => {
+      try {
+        await fetch(`/api/conversations/${conversationId}/messages/${messageId}/stats`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ stats }),
+        });
+      } catch (error) {
+        console.error('Failed to persist resolved stats:', error);
       }
     },
   }), [conversationId, initialMessages, initialMessageCount, saveMessage, renameConversation]);

--- a/src/components/MessageStats.tsx
+++ b/src/components/MessageStats.tsx
@@ -9,8 +9,37 @@ interface MessageStatsProps {
 export function MessageStats({ stats }: MessageStatsProps) {
   if (!stats) return null;
 
-  // When tokens are unavailable, show a hint but still display execution time
-  if (stats.tokensUnavailable) {
+  const { statsStatus } = stats;
+
+  // Loading state - pending or polling
+  if (statsStatus === 'pending' || statsStatus === 'polling') {
+    return (
+      <div className="mt-2 pt-2 border-t border-white/5">
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500">
+          <span className="flex items-center gap-1.5">
+            <div className="w-3 h-3 border border-zinc-500 border-t-transparent rounded-full animate-spin" />
+            Fetching token stats...
+          </span>
+          <span>Time: {stats.executionTimeMs ? `${(stats.executionTimeMs / 1000).toFixed(1)}s` : '-'}</span>
+        </div>
+      </div>
+    );
+  }
+
+  // Failed state - polling timed out
+  if (statsStatus === 'failed') {
+    return (
+      <div className="mt-2 pt-2 border-t border-white/5">
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500">
+          <span title="Token stats unavailable (polling timeout)">Tokens: —</span>
+          <span>Time: {stats.executionTimeMs ? `${(stats.executionTimeMs / 1000).toFixed(1)}s` : '-'}</span>
+        </div>
+      </div>
+    );
+  }
+
+  // Unavailable state - Braintrust not configured or legacy tokensUnavailable
+  if (statsStatus === 'unavailable' || stats.tokensUnavailable) {
     return (
       <div className="mt-2 pt-2 border-t border-white/5">
         <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500">
@@ -21,6 +50,7 @@ export function MessageStats({ stats }: MessageStatsProps) {
     );
   }
 
+  // Resolved state (or no status = legacy behavior) - display all stats
   return (
     <div className="mt-2 pt-2 border-t border-white/5">
       <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500">

--- a/src/hooks/useStatsPolling.ts
+++ b/src/hooks/useStatsPolling.ts
@@ -1,0 +1,153 @@
+'use client';
+
+import { useRef, useCallback, useEffect } from 'react';
+import type { MessageStats } from '@/lib/messages/transform';
+
+interface PollConfig {
+  rootSpanId: string;
+  messageId: string;
+  conversationId: string;
+}
+
+interface UseStatsPollingOptions {
+  onStatsResolved: (messageId: string, stats: MessageStats) => void;
+  maxAttempts?: number;
+  baseInterval?: number;
+  consecutiveMatchesRequired?: number;
+}
+
+interface PollState {
+  attempt: number;
+  consecutiveMatches: number;
+  lastStats: MessageStats | null;
+  timeoutId: NodeJS.Timeout | null;
+  aborted: boolean;
+}
+
+/**
+ * Hook for polling token stats with eventual consistency.
+ *
+ * Parameters (from issue spec):
+ * - consecutiveMatchesRequired: 3 (ensures stats are stable)
+ * - baseInterval: 2000ms (2 seconds between queries)
+ * - maxAttempts: 8 (16s worst case)
+ */
+export function useStatsPolling(options: UseStatsPollingOptions) {
+  const {
+    onStatsResolved,
+    maxAttempts = 8,
+    baseInterval = 2000,
+    consecutiveMatchesRequired = 3,
+  } = options;
+
+  const activePollsRef = useRef<Map<string, PollState>>(new Map());
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      for (const poll of activePollsRef.current.values()) {
+        poll.aborted = true;
+        if (poll.timeoutId) clearTimeout(poll.timeoutId);
+      }
+      activePollsRef.current.clear();
+    };
+  }, []);
+
+  const startPolling = useCallback((config: PollConfig) => {
+    const { rootSpanId, messageId, conversationId } = config;
+
+    // Don't start duplicate polling for same message
+    if (activePollsRef.current.has(messageId)) return;
+
+    const pollState: PollState = {
+      attempt: 0,
+      consecutiveMatches: 0,
+      lastStats: null,
+      timeoutId: null,
+      aborted: false,
+    };
+    activePollsRef.current.set(messageId, pollState);
+
+    const poll = async () => {
+      if (pollState.aborted) return;
+      pollState.attempt++;
+
+      try {
+        const response = await fetch(
+          `/api/stats/${rootSpanId}?conversationId=${conversationId}`
+        );
+
+        if (!response.ok) {
+          if (response.status === 404) {
+            // Message not found - stop polling with failed status
+            onStatsResolved(messageId, { statsStatus: 'failed' });
+            activePollsRef.current.delete(messageId);
+            return;
+          }
+          throw new Error(`HTTP ${response.status}`);
+        }
+
+        const data = await response.json();
+
+        if (data.status === 'resolved' && data.stats) {
+          // Semantic comparison for consecutive match detection
+          const statsMatch = pollState.lastStats &&
+            pollState.lastStats.promptTokens === data.stats.promptTokens &&
+            pollState.lastStats.completionTokens === data.stats.completionTokens &&
+            pollState.lastStats.cachedTokens === data.stats.cachedTokens &&
+            pollState.lastStats.reasoningTokens === data.stats.reasoningTokens;
+
+          if (statsMatch) {
+            pollState.consecutiveMatches++;
+          } else {
+            pollState.consecutiveMatches = 1;
+            pollState.lastStats = data.stats;
+          }
+
+          // Check if we have enough consecutive matches
+          if (pollState.consecutiveMatches >= consecutiveMatchesRequired) {
+            const resolvedStats: MessageStats = {
+              ...data.stats,
+              statsStatus: 'resolved',
+            };
+            onStatsResolved(messageId, resolvedStats);
+            activePollsRef.current.delete(messageId);
+            return;
+          }
+        }
+      } catch (error) {
+        console.warn(`[StatsPolling] Attempt ${pollState.attempt} failed:`, error);
+      }
+
+      // Check if max attempts reached
+      if (pollState.attempt >= maxAttempts) {
+        // Return best-effort result with failed status
+        onStatsResolved(messageId, {
+          ...pollState.lastStats,
+          statsStatus: 'failed',
+        });
+        activePollsRef.current.delete(messageId);
+        return;
+      }
+
+      // Schedule next poll
+      if (!pollState.aborted) {
+        pollState.timeoutId = setTimeout(poll, baseInterval);
+      }
+    };
+
+    // Start polling
+    poll();
+  }, [onStatsResolved, maxAttempts, baseInterval, consecutiveMatchesRequired]);
+
+  const stopPolling = useCallback((messageId: string) => {
+    const poll = activePollsRef.current.get(messageId);
+    if (poll) {
+      poll.aborted = true;
+      if (poll.timeoutId) clearTimeout(poll.timeoutId);
+      activePollsRef.current.delete(messageId);
+    }
+  }, []);
+
+  return { startPolling, stopPolling };
+}

--- a/src/hooks/useTsugiChat/types.ts
+++ b/src/hooks/useTsugiChat/types.ts
@@ -36,6 +36,9 @@ export interface UsageData {
   } | null;
   executionTimeMs: number;
   agent: 'task' | 'skill';
+  // For eventual consistency
+  rootSpanId?: string;
+  status: 'resolved' | 'pending' | 'unavailable';
 }
 
 /**
@@ -96,4 +99,6 @@ export interface UseTsugiChatOptions {
   conversationId: string;
   initialMessages?: Message[];
   onMessageComplete?: (message: Message, index: number) => void;
+  /** Called when deferred stats are resolved via polling */
+  onStatsResolved?: (messageId: string, stats: MessageStats) => void;
 }

--- a/src/lib/messages/transform.ts
+++ b/src/lib/messages/transform.ts
@@ -13,6 +13,9 @@
 // Type Definitions
 // ============================================================================
 
+/** Stats status for eventual consistency */
+export type StatsStatus = 'pending' | 'polling' | 'resolved' | 'failed' | 'unavailable';
+
 /** Token and timing statistics for a message */
 export interface MessageStats {
   promptTokens?: number;
@@ -21,6 +24,9 @@ export interface MessageStats {
   reasoningTokens?: number;
   executionTimeMs?: number;
   tokensUnavailable?: boolean;
+  // For eventual consistency polling
+  rootSpanId?: string;
+  statsStatus?: StatsStatus;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Decouple stats fetching from streaming response to reduce latency
- Client-side polling replaces blocking `fetchTraceStats()` call
- Stats are persisted to DB when they resolve via polling

## Implementation

| File | Change |
|------|--------|
| `src/lib/messages/transform.ts` | Add `rootSpanId`, `statsStatus` to `MessageStats` |
| `src/hooks/useTsugiChat/types.ts` | Add fields to `UsageData`, add `onStatsResolved` option |
| `src/app/api/agent/route.ts` | Send `status` and `rootSpanId` instead of blocking |
| `src/app/api/stats/[rootSpanId]/route.ts` | **NEW** - Polling endpoint with security |
| `src/hooks/useStatsPolling.ts` | **NEW** - Polling hook |
| `src/hooks/useTsugiChat/hook.ts` | Zod schema, polling integration, re-fetch on load |
| `src/hooks/useTsugiChat/stats-utils.ts` | Check `statsStatus` in cumulative calc |
| `src/app/api/conversations/[id]/messages/[messageId]/stats/route.ts` | **NEW** - PATCH endpoint |
| `src/components/MessageStats.tsx` | Loading/error UI states |
| `src/components/ChatClient.tsx` | Wire up `onStatsResolved` |

## Parameters

| Parameter | Value | Rationale |
|-----------|-------|-----------|
| Consecutive matches required | 3 | Ensures stats are stable |
| Interval between queries | 2 seconds | Balance responsiveness vs API load |
| Max attempts | 8 | 16s worst case, sufficient for slow ingestion |

## Test plan

- [ ] Send a message and verify stats show loading spinner initially
- [ ] Verify stats populate within ~10-16s
- [ ] Test page reload before stats arrive: polling should resume
- [ ] Test page reload after stats resolved: no polling, stats displayed
- [ ] Test with Braintrust unavailable: shows "—" immediately

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)